### PR TITLE
Handle non-colcon components in prefix_path

### DIFF
--- a/colcon_installed_package_information/package_discovery/prefix_path.py
+++ b/colcon_installed_package_information/package_discovery/prefix_path.py
@@ -27,6 +27,8 @@ class PrefixPathPackageDiscovery(PackageDiscoveryExtensionPoint):
 
         for priority, prefix_path in enumerate(get_chained_prefix_path()):
             packages = find_installed_packages(Path(prefix_path))
+            if packages is None:
+                continue
             num_packages = len(packages)
             logger.debug('Found {num_packages} installed packages in '
                          '{prefix_path}'.format_map(locals()))


### PR DESCRIPTION
find_installed_packages() will return None if a component of prefix_path was not built by colcon (e.g. if it's a ROS1 catkin area).
This change allows discovery to ignore the problematic component and continue gracefully.